### PR TITLE
remove zope

### DIFF
--- a/certbot_dns_njalla/dns_njalla.py
+++ b/certbot_dns_njalla/dns_njalla.py
@@ -1,10 +1,6 @@
 """DNS Authenticator for Njalla."""
 import logging
 
-import zope.interface
-from certbot import interfaces
-from certbot import errors
-
 from certbot.plugins import dns_common
 from certbot.plugins import dns_common_lexicon
 
@@ -13,8 +9,6 @@ from lexicon.providers import njalla
 logger = logging.getLogger(__name__)
 
 
-@zope.interface.implementer(interfaces.IAuthenticator)
-@zope.interface.provider(interfaces.IPluginFactory)
 class Authenticator(dns_common.DNSAuthenticator):
     """DNS Authenticator for Njalla
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ install_requires = [
     'dnspython',
     'mock',
     'setuptools',
-    'zope.interface',
     'requests'
 ]
 


### PR DESCRIPTION
zope has been deprecated since the release of Certbot 1.19.0 and the referenced interfaces will be removed in an upcoming version of Certbot.