### PR TITLE
make description iterable

### DIFF
--- a/certbot_dns_njalla/dns_njalla.py
+++ b/certbot_dns_njalla/dns_njalla.py
@@ -15,7 +15,7 @@ class Authenticator(dns_common.DNSAuthenticator):
     This Authenticator uses the Njalla REST API to fulfill a dns-01 challenge.
     """
 
-    description = "Obtain certificates using a DNS TXT record (if you are using Njalla for DNS)."
+    description = ("Obtain certificates using a DNS TXT record (if you are using Njalla for DNS).")
     ttl = 60
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
The description field on the official dns plugin Authenticators are single element tuples: https://github.com/certbot/certbot/blob/master/certbot-dns-cloudflare/certbot_dns_cloudflare/_internal/dns_cloudflare.py#L26

Fixes #5

I have not tested this locally, I develop on a mac and I'm not setup to build snaps. 